### PR TITLE
Fix process never closing if mpv is not installed

### DIFF
--- a/python_mpv_jsonipc.py
+++ b/python_mpv_jsonipc.py
@@ -566,7 +566,8 @@ class MPV:
         """Terminate the connection to MPV and process (if *start_mpv* is used)."""
         if self.mpv_process:
             self.mpv_process.stop()
-        self.mpv_inter.stop()
+        if hasattr(self, 'mpv_inter'):
+            self.mpv_inter.stop()
         self.event_handler.stop()
 
     def command(self, command, *args):


### PR DESCRIPTION
When instantiating the MPV class, If there is an issue before the attribute `mpv_inter` has been set (which can happen if the executable for mpv was not found), the destructor will fail and the event_handler will never be stopped.

So here is a quickfix.

Usecase for using this API without mpv: I need to check if a user has access to the mpv executable or not, and instantiating the MPV class was the fastest way to do it.