### PR TITLE
Ignore Windows socket close failure

### DIFF
--- a/python_mpv_jsonipc.py
+++ b/python_mpv_jsonipc.py
@@ -76,7 +76,10 @@ class WindowsSocket(threading.Thread):
     def stop(self, join=True):
         """Terminate the thread."""
         if self.socket is not None:
-            self.socket.close()
+            try:
+                self.socket.close()
+            except OSError:
+                pass # Ignore socket close failure.
         if join:
             self.join()
 


### PR DESCRIPTION
Using this library on Appveyor CI Windows targets, I have my logs full of tracebacks due to invalid handle when closing `WindowsSocket` objects:

```log
Exception in thread Thread-33:
Traceback (most recent call last):
  File "C:\Python36-x64\lib\multiprocessing\connection.py", line 312, in _recv_bytes
    nread, err = ov.GetOverlappedResult(True)
BrokenPipeError: [WinError 109] The pipe has been ended

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Python36-x64\lib\site-packages\python_mpv_jsonipc.py", line 97, in run
    current_data = self.socket.recv_bytes(2048)
  File "C:\Python36-x64\lib\multiprocessing\connection.py", line 216, in recv_bytes
    buf = self._recv_bytes(maxlength)
  File "C:\Python36-x64\lib\multiprocessing\connection.py", line 321, in _recv_bytes
    raise EOFError
EOFError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Python36-x64\lib\threading.py", line 916, in _bootstrap_inner
    self.run()
  File "C:\Python36-x64\lib\site-packages\python_mpv_jsonipc.py", line 114, in run
    self.quit_callback()
  File "C:\Python36-x64\lib\site-packages\python_mpv_jsonipc.py", line 467, in _quit_callback
    self.terminate(join=False)
  File "C:\Python36-x64\lib\site-packages\python_mpv_jsonipc.py", line 611, in terminate
    self.mpv_inter.stop(join)
  File "C:\Python36-x64\lib\site-packages\python_mpv_jsonipc.py", line 292, in stop
    self.socket.stop(join)
  File "C:\Python36-x64\lib\site-packages\python_mpv_jsonipc.py", line 79, in stop
    self.socket.close()
  File "C:\Python36-x64\lib\multiprocessing\connection.py", line 177, in close
    self._close()
  File "C:\Python36-x64\lib\multiprocessing\connection.py", line 277, in _close
    _CloseHandle(self._handle)
OSError: [WinError 6] The handle is invalid
```

Some of those exceptions make my tests to fail randomly.

Calling `self.socket.close` in the `stop` method raises an `OSError` if the connection is already closed. I use the same strategy as in the `UnixSocket` class and catch the exception silently.