### PR TITLE
Add a delay after MPV startup failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 dist
 build
 python_mpv_jsonipc.egg-info
+.vscode

--- a/setup.py
+++ b/setup.py
@@ -5,21 +5,21 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
-    name='python-mpv-jsonipc',
-    version='1.2.0',
+    name="python-mpv-jsonipc",
+    version="1.2.1",
     author="Ian Walton",
     author_email="iwalton3@gmail.com",
     description="Python API to MPV using JSON IPC",
-    license='Apache-2.0',
-    long_description=open('README.md').read(),
+    license="Apache-2.0",
+    long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     url="https://github.com/iwalton3/python-mpv-jsonipc",
-    py_modules=['python_mpv_jsonipc'],
+    py_modules=["python_mpv_jsonipc"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
-    install_requires=[]
+    python_requires=">=3.6",
+    install_requires=[],
 )


### PR DESCRIPTION
This pull request primarily adds a delay after failure to start MPV.
It also makes this delay and the amount of times to retry after failure configurable via constructor parameters.

This delay should help prevent startup issues of MPV in certain instances, especially when running on boot (an issue I run into often with jellyfin-mpv-shim)