### PR TITLE
fix: suppress expected socket errors during intentional shutdown

### DIFF
--- a/python_mpv_jsonipc.py
+++ b/python_mpv_jsonipc.py
@@ -52,6 +52,7 @@ class WindowsSocket(threading.Thread):
         ipc_socket = "\\\\.\\pipe\\" + ipc_socket
         self.callback = callback
         self.quit_callback = quit_callback
+        self._stopping = False
 
         access = _winapi.GENERIC_READ | _winapi.GENERIC_WRITE
         limit = 5 # Connection may fail at first. Try 5 times.
@@ -75,6 +76,7 @@ class WindowsSocket(threading.Thread):
 
     def stop(self, join=True):
         """Terminate the thread."""
+        self._stopping = True
         if self.socket is not None:
             try:
                 self.socket.close()
@@ -116,7 +118,9 @@ class WindowsSocket(threading.Thread):
             if self.quit_callback:
                 self.quit_callback()
         except Exception as ex:
-            log.error("Pipe connection died.", exc_info=1)
+            # Only log if not intentionally stopping
+            if not self._stopping:
+                log.error("Pipe connection died.", exc_info=1)
             if self.quit_callback:
                 self.quit_callback()
 
@@ -137,6 +141,7 @@ class UnixSocket(threading.Thread):
         self.ipc_socket = ipc_socket
         self.callback = callback
         self.quit_callback = quit_callback
+        self._stopping = False
         self.socket = socket.socket(socket.AF_UNIX)
         self.socket.connect(self.ipc_socket)
 
@@ -147,6 +152,7 @@ class UnixSocket(threading.Thread):
 
     def stop(self, join=True):
         """Terminate the thread."""
+        self._stopping = True
         if self.socket is not None:
             try:
                 self.socket.shutdown(socket.SHUT_WR)
@@ -184,7 +190,9 @@ class UnixSocket(threading.Thread):
                     self.callback(json_data)
                 data = b''
         except Exception as ex:
-            log.error("Socket connection died.", exc_info=1)
+            # Only log if not intentionally stopping
+            if not self._stopping:
+                log.error("Socket connection died.", exc_info=1)
         if self.quit_callback:
             self.quit_callback()
 


### PR DESCRIPTION
# Fix spurious socket error logging during intentional shutdown

Fixes #11

## Problem

When the application shuts down (e.g., via Ctrl+C or calling `terminate()`), the socket/pipe threads are often blocked in `recv()` or `recv_bytes()` calls. When `stop()` closes the socket, this causes `OSError: [Errno 9] Bad file descriptor` (on Unix) or similar errors (on Windows) to be logged, even though this is expected behavior during intentional shutdown.

### Example Error Log

```
2026-01-02 02:39:53,725 [   ERROR] mpv-jsonipc: Socket connection died.
Traceback (most recent call last):
  File "python_mpv_jsonipc.py", line 171, in run
    current_data = self.socket.recv(1024)
OSError: [Errno 9] Bad file descriptor
```

This error appears intermittently during normal shutdown due to a race condition:
1. Main thread calls `stop()` → closes socket
2. Socket thread is blocked in `recv()` → raises `OSError` when socket closes
3. Exception handler logs it as an error

### Impact

- **User confusion**: Spurious error messages during normal operation
- **Log noise**: Makes it harder to identify actual connection problems
- **False alarms**: Monitoring systems may flag these as issues

## Solution

Add a `_stopping` flag to both `UnixSocket` and `WindowsSocket` classes to distinguish between intentional shutdown and unexpected disconnection:

1. **Initialize flag**: `self._stopping = False` in `__init__()`
2. **Set flag on shutdown**: `self._stopping = True` in `stop()` before closing socket
3. **Conditional logging**: In `run()` exception handler, only log if `not self._stopping`

### Code Changes

#### UnixSocket class:
- `__init__`: Added `self._stopping = False` (line 144)
- `stop()`: Added `self._stopping = True` before closing (line 155)
- `run()`: Changed error logging to `if not self._stopping:` (lines 193-195)

#### WindowsSocket class:
- `__init__`: Added `self._stopping = False` (line 55)
- `stop()`: Added `self._stopping = True` before closing (line 79)
- `run()`: Changed error logging to `if not self._stopping:` (lines 121-123)

### Why This Works

The flag is set **before** closing the socket, ensuring the socket thread sees it when the exception occurs. This creates a happens-before relationship:

```
Main Thread:              Socket Thread:
stop() called
  ↓
_stopping = True
  ↓
socket.close()
                          recv() raises OSError
                            ↓
                          Check _stopping flag
                            ↓
                          _stopping == True
                            ↓
                          Suppress error log ✓
```

## Testing

Tested with [jellyfin-mpv-shim](https://github.com/jellyfin/jellyfin-mpv-shim) on macOS (external MPV mode):

### Test Scenarios

✅ **Ctrl+C shutdown**: Clean exit, no "Bad file descriptor" error  
✅ **Normal stop operations**: No spurious errors logged  
✅ **Playback stop/start cycles**: Clean transitions  
✅ **Unexpected errors preserved**: Flag remains `False` for actual connection issues

### Before Fix
```
2026-01-02 02:39:53,724 [    INFO] root: Stopping services...
2026-01-02 02:39:53,725 [   ERROR] mpv-jsonipc: Socket connection died.
Traceback (most recent call last):
  File "python_mpv_jsonipc.py", line 171, in run
    current_data = self.socket.recv(1024)
OSError: [Errno 9] Bad file descriptor
```

### After Fix
```
2026-01-02 04:00:59,625 [    INFO] root: Stopping services...
2026-01-02 04:00:59,670 [    INFO] JELLYFIN.jellyfin_apiclient_python.ws_client: ---<[ websocket ]
```

Clean shutdown with no spurious errors! 🎉

## Backward Compatibility

✅ **No breaking changes**: Only internal implementation detail  
✅ **No API changes**: Public interface remains identical  
✅ **No performance impact**: Single boolean flag check  
✅ **Thread-safe**: Flag is set before socket operations

## Alternative Approaches Considered

1. **Catch specific exception types**: Doesn't work because `OSError` is legitimate for both cases
2. **Set socket to non-blocking**: Would require significant refactoring
3. **Use socket timeout**: Adds latency to shutdown
4. **Suppress all errors in stop()**: Loses visibility of real problems

The flag-based approach is the cleanest solution that preserves error visibility while eliminating false positives.

## Related Issues

This pattern is common in socket-based threading code. Similar fixes have been implemented in other projects:
- Python's `socketserver` module uses shutdown flags
- Many async I/O libraries use cancellation tokens

## Checklist

- [x] Code changes implemented
- [x] Tested on Unix (macOS)
- [x] Tested with real-world application (jellyfin-mpv-shim)
- [x] No breaking changes
- [x] Commit message follows best practices
- [ ] Maintainer review
