### PR TITLE
🐛 fix: make internal threads daemon to prevent shutdown hang

### DIFF
--- a/python_mpv_jsonipc.py
+++ b/python_mpv_jsonipc.py
@@ -72,6 +72,7 @@ class WindowsSocket(threading.Thread):
             self.callback = lambda data: None
 
         threading.Thread.__init__(self)
+        self.daemon = True
 
     def stop(self, join=True):
         """Terminate the thread."""
@@ -144,6 +145,7 @@ class UnixSocket(threading.Thread):
             self.callback = lambda data: None
 
         threading.Thread.__init__(self)
+        self.daemon = True
 
     def stop(self, join=True):
         """Terminate the thread."""
@@ -356,6 +358,7 @@ class EventHandler(threading.Thread):
         """Create an instance of the thread."""
         self.queue = queue.Queue()
         threading.Thread.__init__(self)
+        self.daemon = True
 
     def put_task(self, func, *args):
         """


### PR DESCRIPTION
## Summary

- Make `WindowsSocket`, `UnixSocket`, and `EventHandler` threads daemon threads

## Problem

When MPV is killed externally (e.g., Cmd+Q on macOS), the non-daemon threads block on I/O operations (`socket.recv()`, `queue.get()`) and Python's interpreter shutdown waits for them indefinitely. This causes applications using this library to hang for minutes until MPV fully exits.

## Solution

Setting `self.daemon = True` on all internal threads allows Python to exit cleanly without waiting for these threads to finish.