### PR TITLE
Fix spurious "MPV start timed out" on Windows (named-pipe readiness check)

### DIFF
--- a/python_mpv_jsonipc.py
+++ b/python_mpv_jsonipc.py
@@ -198,6 +198,26 @@ class UnixSocket(threading.Thread):
         if self.quit_callback:
             self.quit_callback()
 
+def _ipc_endpoint_ready(ipc_socket):
+    """Return True once MPV's IPC endpoint is available.
+
+    On POSIX the endpoint is a filesystem socket, so ``os.path.exists`` works. On
+    Windows it is a *named pipe*, for which ``os.path.exists`` is always False — so we
+    probe it with ``WaitNamedPipe`` instead. Using ``os.path.exists`` on Windows made
+    the startup poll never detect the pipe, raising a spurious "MPV start timed out".
+    """
+    if os.name != 'nt':
+        return os.path.exists(ipc_socket)
+    try:
+        _winapi.WaitNamedPipe(ipc_socket, 0)
+        return True
+    except FileNotFoundError:
+        return False
+    except OSError:
+        # Pipe exists but all instances are momentarily busy — it is present.
+        return True
+
+
 class MPVProcess:
     """
     Manages an MPV process, ensuring the socket or pipe is available. (Internal)
@@ -248,7 +268,7 @@ class MPVProcess:
         for _ in range(100): # Give MPV 10 seconds to start.
             time.sleep(0.1)
             self.process.poll()
-            if os.path.exists(ipc_socket):
+            if _ipc_endpoint_ready(ipc_socket):
                 ipc_exists = True
                 log.debug("Found MPV socket.")
                 break


### PR DESCRIPTION
## Problem

On Windows, `MPV(start_mpv=True, ...)` reliably fails with `MPVError: MPV start timed out` even when MPV launches correctly and the IPC pipe is live.

## Root cause

`MPVProcess.__init__` polls for the IPC endpoint with:

```python
for _ in range(100):
    time.sleep(0.1)
    if os.path.exists(ipc_socket):   # ipc_socket == r'\.\pipe\<name>' on Windows
        ...
```

`os.path.exists()` is **always False for Windows named-pipe paths** (`\.\pipe\...`) — `os.stat` can't stat a pipe — so the loop never detects the pipe and the `else` branch raises `MPV start timed out`, despite MPV being up. POSIX is unaffected because there the endpoint really is a filesystem socket.

## Fix

Add `_ipc_endpoint_ready()`: keep `os.path.exists` on POSIX, but on Windows probe the pipe with `_winapi.WaitNamedPipe` (the transport layer already depends on `_winapi`). Minimal, stdlib-only, no new deps, no API change.

## Verification

Against MPV v0.41 on Windows 10 / Python 3.14:

- **Before:** `MPVError: MPV start timed out` (every run)
- **After:** `MPV` connects in ~0.5s; `idle_active` and subsequent commands work.

```python
m = MPV(start_mpv=True, ipc_socket='test', mpv_location=r'...\mpv.exe', vid='no')
# before: raises MPV start timed out
# after:  connects, m.idle_active -> True
```